### PR TITLE
buildin workflow rules

### DIFF
--- a/pkg/bio/chunk.go
+++ b/pkg/bio/chunk.go
@@ -172,7 +172,7 @@ func (c *chunkReader) Close() {
 		delete(fileChunkReaders, c.entry.ID)
 		fileChunkMux.Unlock()
 		if c.needCompact {
-			events.Publish(events.EntryActionTopic(events.TopicFileActionFmt, events.ActionTypeCompact),
+			events.Publish(events.EntryActionTopic(events.TopicNamespaceFile, events.ActionTypeCompact),
 				buildCompactEvent(c.entry))
 		}
 		c.page.close()

--- a/pkg/bio/utils.go
+++ b/pkg/bio/utils.go
@@ -42,10 +42,10 @@ func buildCompactEvent(entry *types.Metadata) *types.EntryEvent {
 	return &types.EntryEvent{
 		Id:              uuid.New().String(),
 		Type:            events.ActionTypeCompact,
-		Source:          fmt.Sprintf("/object/%d", entry.ID),
+		Source:          fmt.Sprintf("/entry/%d", entry.ID),
 		SpecVersion:     "1.0",
 		Time:            time.Now(),
-		RefType:         "object",
+		RefType:         "entry",
 		RefID:           entry.ID,
 		DataContentType: "application/json",
 		Data:            types.NewEventData(entry),

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -159,7 +159,6 @@ func (c *controller) UpdateEntry(ctx context.Context, entry *types.Metadata) err
 		c.logger.Errorw("save entry error", "entry", entryID, "err", err)
 		return err
 	}
-	dentry.PublicEntryActionEvent(events.ActionTypeUpdate, en)
 	return nil
 }
 
@@ -187,7 +186,6 @@ func (c *controller) DestroyEntry(ctx context.Context, parentId, entryId int64, 
 		c.logger.Errorw("delete entry failed", "entry", entryId, "err", err.Error())
 		return err
 	}
-	dentry.PublicEntryActionEvent(events.ActionTypeDestroy, en)
 	return nil
 }
 
@@ -289,7 +287,6 @@ func (c *controller) ChangeEntryParent(ctx context.Context, targetId, oldParentI
 		c.logger.Errorw("change object parent failed", "target", targetId, "newParent", newParentId, "newName", newName, "err", err)
 		return err
 	}
-	dentry.PublicEntryActionEvent(events.ActionTypeChangeParent, target)
 	return nil
 }
 

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -211,7 +211,7 @@ func (c *controller) MirrorEntry(ctx context.Context, srcId, dstParentId int64, 
 	}
 	c.logger.Debugw("mirror entry", "src", srcId, "dstParent", dstParentId, "entry", entry.ID)
 
-	events.Publish(events.EntryActionTopic(events.TopicEntryActionFmt, events.ActionTypeMirror),
+	events.Publish(events.EntryActionTopic(events.TopicNamespaceEntry, events.ActionTypeMirror),
 		dentry.BuildEntryEvent(events.ActionTypeMirror, entry))
 	return entry, nil
 }

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -137,7 +137,6 @@ func (c *controller) CreateEntry(ctx context.Context, parentId int64, attr types
 		c.logger.Errorw("create entry error", "parent", parentId, "entryName", attr.Name, "err", err)
 		return nil, err
 	}
-	dentry.PublicEntryActionEvent(events.ActionTypeCreate, entry)
 	return entry, nil
 }
 

--- a/pkg/controller/fs.go
+++ b/pkg/controller/fs.go
@@ -70,12 +70,12 @@ func (c *controller) FsInfo(ctx context.Context) Info {
 }
 
 func (c *controller) StartBackendTask(stopCh chan struct{}) {
-	st, err := dispatch.Init(c.entry, c.notify, c.meta)
+	st, err := dispatch.Init(c.entry, c.workflow, c.notify, c.meta)
 	if err != nil {
 		c.logger.Panicf("start backend task failed: %s", err)
 	}
 	go st.Run(stopCh)
-	go c.workflow.StartCron(stopCh)
+	go c.workflow.Start(stopCh)
 }
 
 func (c *controller) SetupShutdownHandler(stopCh chan struct{}) chan struct{} {

--- a/pkg/dentry/event.go
+++ b/pkg/dentry/event.go
@@ -17,6 +17,7 @@
 package dentry
 
 import (
+	"context"
 	"fmt"
 	"github.com/basenana/nanafs/pkg/events"
 	"github.com/basenana/nanafs/pkg/types"
@@ -24,12 +25,34 @@ import (
 	"time"
 )
 
-func PublicEntryActionEvent(actionType string, en *types.Metadata) {
-	events.Publish(events.EntryActionTopic(events.TopicEntryActionFmt, actionType), BuildEntryEvent(actionType, en))
+type entryEvent struct {
+	entryID    int64
+	topicNS    string
+	actionType string
 }
 
-func PublicFileActionEvent(actionType string, en *types.Metadata) {
-	events.Publish(events.EntryActionTopic(events.TopicFileActionFmt, actionType), BuildEntryEvent(actionType, en))
+func (m *manager) publicEntryActionEvent(topicNS, actionType string, entryID int64) {
+	m.eventQ <- &entryEvent{entryID: entryID, topicNS: topicNS, actionType: actionType}
+}
+
+func (m *manager) entryActionEventHandler() {
+	m.logger.Debugw("start entryActionEventHandler")
+	for evt := range m.eventQ {
+		if evt.entryID == 0 {
+			m.logger.Errorw("handle entry event error: entry id is empty", "entry", evt.entryID, "action", evt.actionType)
+			continue
+		}
+		en, err := m.store.GetEntry(context.Background(), evt.entryID)
+		if err != nil {
+			m.logger.Errorw("encounter error when handle entry event", "entry", evt.entryID, "action", evt.actionType, "err", err)
+			continue
+		}
+		events.Publish(events.EntryActionTopic(evt.topicNS, evt.actionType), BuildEntryEvent(evt.actionType, en))
+	}
+}
+
+func PublicEntryActionEvent(actionType string, en *types.Metadata) {
+	events.Publish(events.EntryActionTopic(events.TopicNamespaceEntry, actionType), BuildEntryEvent(actionType, en))
 }
 
 func BuildEntryEvent(actionType string, entry *types.Metadata) *types.EntryEvent {

--- a/pkg/dentry/event.go
+++ b/pkg/dentry/event.go
@@ -36,10 +36,10 @@ func BuildEntryEvent(actionType string, entry *types.Metadata) *types.EntryEvent
 	return &types.EntryEvent{
 		Id:              uuid.New().String(),
 		Type:            actionType,
-		Source:          fmt.Sprintf("/object/%d", entry.ID),
+		Source:          fmt.Sprintf("/entry/%d", entry.ID),
 		SpecVersion:     "1.0",
 		Time:            time.Now(),
-		RefType:         "object",
+		RefType:         "entry",
 		RefID:           entry.ID,
 		DataContentType: "application/json",
 		Data:            types.NewEventData(entry),

--- a/pkg/dentry/file.go
+++ b/pkg/dentry/file.go
@@ -208,11 +208,7 @@ func (s *symlink) Flush(ctx context.Context) (err error) {
 
 func (s *symlink) Close(ctx context.Context) error {
 	defer trace.StartRegion(ctx, "dentry.symlink.Close").End()
-	en, err := s.mgr.GetEntry(ctx, s.entryID)
-	if err != nil {
-		return err
-	}
-	defer PublicFileActionEvent(events.ActionTypeClose, en)
+	defer s.mgr.publicEntryActionEvent(events.TopicNamespaceFile, events.ActionTypeClose, s.entryID)
 	defer decreaseOpenedFile(s.entryID)
 	return s.Flush(ctx)
 }

--- a/pkg/dentry/group.go
+++ b/pkg/dentry/group.go
@@ -19,6 +19,7 @@ package dentry
 import (
 	"context"
 	"fmt"
+	"github.com/basenana/nanafs/pkg/events"
 	"github.com/basenana/nanafs/pkg/metastore"
 	"github.com/basenana/nanafs/pkg/plugin"
 	"github.com/basenana/nanafs/pkg/plugin/pluginapi"
@@ -133,6 +134,7 @@ func (g *stdGroup) CreateEntry(ctx context.Context, attr types.EntryAttr) (*type
 		ed.GroupFilter = attr.GroupFilter
 	default:
 		// skip create extend data
+		PublicEntryActionEvent(events.ActionTypeCreate, entry)
 		return entry, nil
 	}
 
@@ -146,6 +148,8 @@ func (g *stdGroup) CreateEntry(ctx context.Context, attr types.EntryAttr) (*type
 			return nil, err
 		}
 	}
+
+	PublicEntryActionEvent(events.ActionTypeCreate, entry)
 	return entry, nil
 }
 

--- a/pkg/dentry/group.go
+++ b/pkg/dentry/group.go
@@ -64,6 +64,7 @@ func (e emptyGroup) ListChildren(ctx context.Context) ([]*types.Metadata, error)
 type stdGroup struct {
 	entryID int64
 	name    string
+	mgr     *manager
 	store   metastore.DEntry
 }
 
@@ -134,7 +135,7 @@ func (g *stdGroup) CreateEntry(ctx context.Context, attr types.EntryAttr) (*type
 		ed.GroupFilter = attr.GroupFilter
 	default:
 		// skip create extend data
-		PublicEntryActionEvent(events.ActionTypeCreate, entry)
+		g.mgr.publicEntryActionEvent(events.TopicNamespaceEntry, events.ActionTypeCreate, entry.ID)
 		return entry, nil
 	}
 
@@ -149,7 +150,7 @@ func (g *stdGroup) CreateEntry(ctx context.Context, attr types.EntryAttr) (*type
 		}
 	}
 
-	PublicEntryActionEvent(events.ActionTypeCreate, entry)
+	g.mgr.publicEntryActionEvent(events.TopicNamespaceEntry, events.ActionTypeCreate, entry.ID)
 	return entry, nil
 }
 
@@ -159,7 +160,7 @@ func (g *stdGroup) UpdateEntry(ctx context.Context, entry *types.Metadata) error
 	if err != nil {
 		return err
 	}
-	PublicEntryActionEvent(events.ActionTypeUpdate, entry)
+	g.mgr.publicEntryActionEvent(events.TopicNamespaceEntry, events.ActionTypeUpdate, entry.ID)
 	return nil
 }
 
@@ -176,7 +177,7 @@ func (g *stdGroup) RemoveEntry(ctx context.Context, entryId int64) error {
 	if err != nil {
 		return err
 	}
-	PublicEntryActionEvent(events.ActionTypeDestroy, en)
+	g.mgr.publicEntryActionEvent(events.TopicNamespaceEntry, events.ActionTypeDestroy, entryId)
 	return nil
 }
 

--- a/pkg/dentry/manager.go
+++ b/pkg/dentry/manager.go
@@ -340,7 +340,13 @@ func (m *manager) ChangeEntryParent(ctx context.Context, targetEntryId int64, ov
 	}
 
 	if oldParent.Storage == externalStorage || newParent.Storage == externalStorage || oldParent.Storage != newParent.Storage {
-		return m.changeEntryParentByFileCopy(ctx, target, oldParent, newParent, newName, opt)
+		err = m.changeEntryParentByFileCopy(ctx, target, oldParent, newParent, newName, opt)
+		if err != nil {
+			m.logger.Errorw("change entry parent by file copy failed", "err", err)
+			return err
+		}
+		PublicEntryActionEvent(events.ActionTypeChangeParent, target)
+		return nil
 	}
 
 	err = m.store.ChangeEntryParent(ctx, targetEntryId, newParentId, newName, opt)
@@ -348,6 +354,7 @@ func (m *manager) ChangeEntryParent(ctx context.Context, targetEntryId int64, ov
 		m.logger.Errorw("change object parent failed", "entry", target.ID, "newParent", newParentId, "newName", newName, "err", err)
 		return err
 	}
+	PublicEntryActionEvent(events.ActionTypeChangeParent, target)
 	return nil
 }
 

--- a/pkg/dispatch/executor.go
+++ b/pkg/dispatch/executor.go
@@ -16,12 +16,3 @@
 
 package dispatch
 
-import (
-	"context"
-	"github.com/basenana/nanafs/pkg/types"
-)
-
-type executor interface {
-	handleEvent(ctx context.Context, evt *types.EntryEvent) error
-	execute(ctx context.Context, task *types.ScheduledTask) error
-}

--- a/pkg/dispatch/mainttask.go
+++ b/pkg/dispatch/mainttask.go
@@ -18,7 +18,6 @@ package dispatch
 
 import (
 	"context"
-	"fmt"
 	"github.com/basenana/nanafs/pkg/dentry"
 	"github.com/basenana/nanafs/pkg/events"
 	"github.com/basenana/nanafs/pkg/metastore"
@@ -76,7 +75,7 @@ func (c *compactExecutor) handleEvent(ctx context.Context, evt *types.EntryEvent
 func (c *compactExecutor) execute(ctx context.Context, task *types.ScheduledTask) error {
 	entry := task.Event.Data
 	if dentry.IsFileOpened(entry.ID) {
-		return fmt.Errorf("file is opened")
+		return ErrNeedRetry
 	}
 
 	en, err := c.entry.GetEntry(ctx, entry.ID)
@@ -106,55 +105,54 @@ func (c *entryCleanExecutor) handleEvent(ctx context.Context, evt *types.EntryEv
 		return nil
 	}
 
+	if types.IsGroup(entry.Kind) {
+		return nil
+	}
+
 	task, err := getWaitingTask(ctx, c.recorder, maintainTaskIDEntryCleanup, evt)
 	if err != nil {
 		return err
 	}
 
-	needUpdate := false
-	if task == nil {
-		task = &types.ScheduledTask{
-			TaskID:         maintainTaskIDEntryCleanup,
-			Status:         types.ScheduledTaskInitial,
-			RefType:        evt.RefType,
-			RefID:          evt.RefID,
-			CreatedTime:    time.Now(),
-			ExpirationTime: time.Now().Add(time.Hour),
-			Event:          *evt,
-		}
-		needUpdate = true
+	if task != nil {
+		return nil
 	}
 
-	if types.IsGroup(entry.Kind) || (!dentry.IsFileOpened(evt.RefID)) {
-		task.Status = types.ScheduledTaskWait
-		needUpdate = true
+	task = &types.ScheduledTask{
+		TaskID:         maintainTaskIDEntryCleanup,
+		Status:         types.ScheduledTaskWait,
+		RefType:        evt.RefType,
+		RefID:          evt.RefID,
+		CreatedTime:    time.Now(),
+		ExpirationTime: time.Now().Add(time.Hour),
+		Event:          *evt,
 	}
-
-	if needUpdate {
-		return c.recorder.SaveTask(ctx, task)
-	}
-	return nil
+	return c.recorder.SaveTask(ctx, task)
 }
 
 func (c *entryCleanExecutor) execute(ctx context.Context, task *types.ScheduledTask) error {
-	evt := task.Event
-	en, err := c.entry.GetEntry(ctx, evt.RefID)
+	entry := task.Event.Data
+	if dentry.IsFileOpened(entry.ID) {
+		return ErrNeedRetry
+	}
+
+	en, err := c.entry.GetEntry(ctx, entry.ID)
 	if err != nil {
-		c.logger.Errorw("[entryCleanExecutor] get entry failed", "entry", evt.RefID, "task", task.ID, "err", err)
+		c.logger.Errorw("[entryCleanExecutor] get entry failed", "entry", entry.ID, "task", task.ID, "err", err)
 		return err
 	}
 
 	if !types.IsGroup(en.Kind) {
 		err = c.entry.CleanEntryData(ctx, en.ID)
 		if err != nil {
-			c.logger.Errorw("[entryCleanExecutor] get entry failed", "entry", evt.RefID, "task", task.ID, "err", err)
+			c.logger.Errorw("[entryCleanExecutor] get entry failed", "entry", entry.ID, "task", task.ID, "err", err)
 			return err
 		}
 	}
 
 	err = c.entry.DestroyEntry(ctx, en.ID)
 	if err != nil {
-		c.logger.Errorw("[entryCleanExecutor] get entry failed", "entry", evt.RefID, "task", task.ID, "err", err)
+		c.logger.Errorw("[entryCleanExecutor] get entry failed", "entry", entry.ID, "task", task.ID, "err", err)
 		return err
 	}
 	return nil

--- a/pkg/dispatch/utils.go
+++ b/pkg/dispatch/utils.go
@@ -26,6 +26,11 @@ import (
 )
 
 var (
+	ErrNeedRetry   = fmt.Errorf("need retry")
+	defaultTimeout = time.Hour * 6
+)
+
+var (
 	taskExecutionLatency = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Name:    "dispatch_task_execution_latency_seconds",

--- a/pkg/dispatch/workflow.go
+++ b/pkg/dispatch/workflow.go
@@ -26,33 +26,106 @@ import (
 	"github.com/basenana/nanafs/pkg/types"
 	"github.com/basenana/nanafs/pkg/workflow"
 	"github.com/basenana/nanafs/pkg/workflow/jobrun"
+	"github.com/basenana/nanafs/utils/logger"
 	"go.uber.org/zap"
+	"time"
 )
 
-type workflowAction struct {
+const (
+	workflowAutoTriggerExecID = "task.workflow.auto_trigger"
+)
+
+type workflowExecutor struct {
 	entry    dentry.Manager
 	manager  workflow.Manager
 	recorder metastore.ScheduledTaskRecorder
 	logger   *zap.SugaredLogger
 }
 
-func (w workflowAction) handleEvent(ctx context.Context, evt *types.EntryEvent) error {
-	if evt.Type != events.ActionTypeClose || !dentry.IsFileOpened(evt.RefID) {
+func (w workflowExecutor) handleEvent(ctx context.Context, evt *types.EntryEvent) error {
+	if evt.Type != events.ActionTypeCreate {
 		return nil
 	}
-	if evt.RefType != "object" {
+	if evt.RefType != "entry" {
 		return nil
 	}
 
 	en, err := w.entry.GetEntry(ctx, evt.RefID)
 	if err != nil {
-		w.logger.Errorw("[workflowAction] get entry failed", "entry", evt.RefID, "err", err)
+		w.logger.Errorw("[workflowAutoTrigger] get entry failed", "entry", evt.RefID, "err", err)
+		return err
+	}
+	ed, err := w.entry.GetEntryExtendData(ctx, en.ID)
+	if err != nil {
+		w.logger.Errorw("[workflowAutoTrigger] get entry extend data failed", "entry", evt.RefID, "err", err)
+		return err
+	}
+	labels, err := w.entry.GetEntryLabels(ctx, en.ID)
+	if err != nil {
+		w.logger.Errorw("[workflowAutoTrigger] get entry labels failed", "entry", evt.RefID, "err", err)
 		return err
 	}
 
 	wfList, err := w.recorder.ListWorkflow(ctx)
 	if err != nil {
-		w.logger.Errorw("[workflowAction] list workflow failed", "entry", evt.RefID, "err", err)
+		w.logger.Errorw("[workflowAutoTrigger] list workflow failed", "entry", evt.RefID, "err", err)
+		return err
+	}
+
+	for _, wf := range wfList {
+		if !wf.Enable {
+			continue
+		}
+
+		if !rule.Filter(wf.Rule, en, &ed, &labels) {
+			continue
+		}
+
+		task := &types.ScheduledTask{
+			TaskID:         workflowAutoTriggerExecID,
+			Status:         types.ScheduledTaskWait,
+			RefType:        evt.RefType,
+			RefID:          evt.RefID,
+			CreatedTime:    time.Now(),
+			ExpirationTime: time.Now().Add(defaultTimeout),
+			Event:          *evt,
+		}
+		if err = w.recorder.SaveTask(ctx, task); err != nil {
+			w.logger.Errorw("[workflowAutoTrigger] save task to waiting error", "entry", evt.RefID, "err", err.Error())
+			return err
+		}
+		w.logger.Infow("[workflowAutoTrigger] workflow rule matched, job pre-created", "entry", evt.RefID, "workflow", wf.Id)
+		return nil
+	}
+
+	return nil
+}
+
+func (w workflowExecutor) execute(ctx context.Context, task *types.ScheduledTask) error {
+	entry := task.Event.Data
+	if dentry.IsFileOpened(entry.ID) {
+		return ErrNeedRetry
+	}
+
+	en, err := w.entry.GetEntry(ctx, entry.ID)
+	if err != nil {
+		w.logger.Errorw("[workflowAutoTrigger] query entry error", "entry", entry.ID, "err", err.Error())
+		return err
+	}
+	ed, err := w.entry.GetEntryExtendData(ctx, en.ID)
+	if err != nil {
+		w.logger.Errorw("[workflowAutoTrigger] get entry extend data failed", "entry", en.ID, "err", err)
+		return err
+	}
+	labels, err := w.entry.GetEntryLabels(ctx, en.ID)
+	if err != nil {
+		w.logger.Errorw("[workflowAutoTrigger] get entry labels failed", "entry", en.ID, "err", err)
+		return err
+	}
+
+	wfList, err := w.recorder.ListWorkflow(ctx)
+	if err != nil {
+		w.logger.Errorw("[workflowAutoTrigger] list workflow failed", "entry", en.ID, "err", err)
 		return err
 	}
 
@@ -62,32 +135,48 @@ func (w workflowAction) handleEvent(ctx context.Context, evt *types.EntryEvent) 
 			continue
 		}
 
-		// TODO: support extend data and labels
-		if rule.Filter(wf.Rule, en, nil, nil) {
+		if !rule.Filter(wf.Rule, en, &ed, &labels) {
 			continue
 		}
 
-		pendingJob, err := w.recorder.ListWorkflowJob(ctx, types.JobFilter{WorkFlowID: wf.Id, Status: jobrun.InitializingStatus, TargetEntry: evt.RefID})
+		pendingJob, err := w.recorder.ListWorkflowJob(ctx, types.JobFilter{WorkFlowID: wf.Id, Status: jobrun.InitializingStatus, TargetEntry: en.ID})
 		if err != nil {
-			w.logger.Errorw("[workflowAction] query pending job failed", "entry", evt.RefID, "workflow", wf.Id, "err", err)
+			w.logger.Errorw("[workflowAutoTrigger] query pending job failed", "entry", en.ID, "workflow", wf.Id, "err", err)
 			continue
 		}
+
 		if len(pendingJob) > 0 {
 			continue
 		}
 
 		// trigger workflow
-		job, err = w.manager.TriggerWorkflow(ctx, wf.Id, types.WorkflowTarget{EntryID: evt.RefID}, workflow.JobAttr{Reason: fmt.Sprintf("event: %s", evt.Type)})
+		tgt := types.WorkflowTarget{}
+		if types.IsGroup(en.Kind) {
+			tgt.ParentEntryID = en.ID
+		} else {
+			tgt.EntryID = en.ID
+			tgt.ParentEntryID = en.ParentID
+		}
+		job, err = w.manager.TriggerWorkflow(ctx, wf.Id, tgt, workflow.JobAttr{Reason: fmt.Sprintf("event: entry created")})
 		if err != nil {
-			w.logger.Errorw("[workflowAction] workflow trigger failed", "entry", evt.RefID, "workflow", wf.Id, "err", err)
+			w.logger.Errorw("[workflowAutoTrigger] workflow trigger failed", "entry", en.ID, "workflow", wf.Id, "err", err)
 			continue
 		}
-		w.logger.Infow("[workflowAction] new workflow job", "entry", evt.RefID, "workflow", wf.Id, "job", job.Id)
+		w.logger.Infow("[workflowAutoTrigger] new workflow job", "entry", en.ID, "workflow", wf.Id, "job", job.Id)
 	}
-
 	return nil
 }
 
-func (w workflowAction) execute(ctx context.Context, task *types.ScheduledTask) error {
-	return nil
+func registerWorkflowExecutor(
+	executors map[string]executor,
+	entry dentry.Manager,
+	wfMgr workflow.Manager,
+	recorder metastore.ScheduledTaskRecorder) {
+	e := &workflowExecutor{
+		entry:    entry,
+		manager:  wfMgr,
+		recorder: recorder,
+		logger:   logger.NewLogger("workflowExecutor"),
+	}
+	executors[workflowAutoTriggerExecID] = e
 }

--- a/pkg/events/topic.go
+++ b/pkg/events/topic.go
@@ -16,14 +16,9 @@
 
 package events
 
-import (
-	"fmt"
-)
-
 var (
-	TopicAllActions     = "action.*.*"
-	TopicEntryActionFmt = "action.entry.%s"
-	TopicFileActionFmt  = "action.file.%s"
+	TopicNamespaceEntry = "action.entry."
+	TopicNamespaceFile  = "action.file."
 
 	ActionTypeCreate       = "create"
 	ActionTypeUpdate       = "update"
@@ -36,6 +31,6 @@ var (
 	ActionTypeCompact      = "compact"
 )
 
-func EntryActionTopic(topicFmt string, actionType string) string {
-	return fmt.Sprintf(topicFmt, actionType)
+func EntryActionTopic(topicNamespace string, actionType string) string {
+	return topicNamespace + actionType
 }

--- a/pkg/metastore/sql.go
+++ b/pkg/metastore/sql.go
@@ -524,6 +524,7 @@ func (s *sqlMetaStore) RemoveEntry(ctx context.Context, parentID, entryID int64)
 			}
 
 			if entryChildCount > 0 {
+				s.logger.Infow("delete a not empty group", "entryChildCount", entryChildCount)
 				return types.ErrNotEmpty
 			}
 
@@ -1563,7 +1564,10 @@ func queryFilter(tx *gorm.DB, filter types.Filter, scopeIds []int64) *gorm.DB {
 
 	if filter.ParentID != 0 {
 		tx = tx.Where("parent_id = ?", filter.ParentID)
+	} else {
+		tx = tx.Where("parent_id > 0")
 	}
+
 	if filter.RefID != 0 {
 		tx = tx.Where("ref_id = ?", filter.RefID)
 	}

--- a/pkg/metastore/sql_test.go
+++ b/pkg/metastore/sql_test.go
@@ -378,7 +378,7 @@ func InitRootEntry() *types.Metadata {
 		},
 	}
 	root, _ := types.InitNewEntry(nil, types.EntryAttr{Name: "root", Kind: types.GroupKind, Access: acc})
-	root.ID = -1
+	root.ID = 1
 	root.ParentID = root.ID
 	return root
 }

--- a/pkg/plugin/buildin/docloader/csv.go
+++ b/pkg/plugin/buildin/docloader/csv.go
@@ -70,6 +70,7 @@ func (c CSV) Load(_ context.Context) (result []types.FDocument, err error) {
 		}
 
 		rown++
+		// TODO: using HTML fmt?
 		result = append(result, types.FDocument{
 			Content:  strings.Join(content, "\n"),
 			Metadata: map[string]any{"type": csvLoader, "row": rown},

--- a/pkg/plugin/buildin/docloader/pdf.go
+++ b/pkg/plugin/buildin/docloader/pdf.go
@@ -84,6 +84,7 @@ func (p *PDF) Load(_ context.Context) ([]types.FDocument, error) {
 			return nil, err
 		}
 
+		// TODO: using HTML fmt?
 		result = append(result, types.FDocument{
 			Content: text,
 			Metadata: map[string]any{

--- a/pkg/plugin/buildin/docloader/plaintext.go
+++ b/pkg/plugin/buildin/docloader/plaintext.go
@@ -47,6 +47,7 @@ func (l Text) Load(_ context.Context) ([]types.FDocument, error) {
 		return nil, err
 	}
 
+	// TODO: using HTML fmt?
 	return []types.FDocument{
 		{
 			Content:  buf.String(),

--- a/pkg/rule/filter_test.go
+++ b/pkg/rule/filter_test.go
@@ -29,7 +29,7 @@ type object struct {
 
 func TestObjectFilter(t *testing.T) {
 	obj := &object{
-		Metadata: &types.Metadata{ID: 1024, Name: "test_file_1"},
+		Metadata: &types.Metadata{ID: 1024, Name: "test_file_1.txt"},
 		Labels: &types.Labels{Labels: []types.Label{
 			{Key: "test-key-1", Value: "test-val-1"},
 			{Key: "test-key-2", Value: "test-val-2"},
@@ -50,8 +50,13 @@ func TestObjectFilter(t *testing.T) {
 					{
 						Operation: types.RuleOpEqual,
 						Column:    "name",
-						Value:     "test_file_1",
+						Value:     "test_file_1.txt",
 						Labels:    nil,
+					},
+					{
+						Operation: types.RuleOpEndWith,
+						Column:    "name",
+						Value:     "txt",
 					},
 					{
 						Labels: &types.LabelMatch{

--- a/pkg/rule/operation.go
+++ b/pkg/rule/operation.go
@@ -39,7 +39,7 @@ func NewRuleOperation(opType, col, val string) Operation {
 	case types.RuleOpBeginWith:
 		return BeginWith{ColumnKey: col, Content: val}
 	case types.RuleOpEndWith:
-		return BeginWith{ColumnKey: col, Content: val}
+		return EndWith{ColumnKey: col, Content: val}
 	case types.RuleOpPattern:
 		return Pattern{ColumnKey: col, Content: val}
 	case types.RuleOpBefore, types.RuleOpAfter:

--- a/pkg/types/event.go
+++ b/pkg/types/event.go
@@ -33,40 +33,24 @@ type EntryEvent struct {
 }
 
 type EventData struct {
-	ID         int64     `json:"id"`
-	Name       string    `json:"name"`
-	ParentID   int64     `json:"parent_id"`
-	RefID      int64     `json:"ref_id,omitempty"`
-	RefCount   int       `json:"ref_count,omitempty"`
-	Kind       Kind      `json:"kind"`
-	KindMap    int64     `json:"kind_map"`
-	Version    int64     `json:"version"`
-	Dev        int64     `json:"dev"`
-	Namespace  string    `json:"namespace,omitempty"`
-	Storage    string    `json:"storage"`
-	CreatedAt  time.Time `json:"created_at"`
-	ChangedAt  time.Time `json:"changed_at"`
-	ModifiedAt time.Time `json:"modified_at"`
-	AccessAt   time.Time `json:"access_at"`
+	ID        int64  `json:"id"`
+	ParentID  int64  `json:"parent_id"`
+	RefID     int64  `json:"ref_id,omitempty"`
+	Kind      Kind   `json:"kind"`
+	KindMap   int64  `json:"kind_map"`
+	Namespace string `json:"namespace,omitempty"`
+	Storage   string `json:"storage"`
 }
 
 func NewEventData(entry *Metadata) EventData {
 	return EventData{
-		ID:         entry.ID,
-		Name:       entry.Name,
-		ParentID:   entry.ParentID,
-		RefID:      entry.RefID,
-		RefCount:   entry.RefCount,
-		Kind:       entry.Kind,
-		KindMap:    entry.KindMap,
-		Version:    entry.Version,
-		Dev:        entry.Dev,
-		Namespace:  entry.Namespace,
-		Storage:    entry.Storage,
-		CreatedAt:  entry.CreatedAt,
-		ChangedAt:  entry.ChangedAt,
-		ModifiedAt: entry.ModifiedAt,
-		AccessAt:   entry.AccessAt,
+		ID:        entry.ID,
+		ParentID:  entry.ParentID,
+		RefID:     entry.RefID,
+		Kind:      entry.Kind,
+		KindMap:   entry.KindMap,
+		Namespace: entry.Namespace,
+		Storage:   entry.Storage,
 	}
 }
 

--- a/pkg/workflow/buildin.go
+++ b/pkg/workflow/buildin.go
@@ -1,0 +1,127 @@
+/*
+ Copyright 2023 NanaFS Authors.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package workflow
+
+import (
+	"context"
+	"fmt"
+	"github.com/basenana/nanafs/pkg/types"
+	"reflect"
+)
+
+func registerBuildInWorkflow(ctx context.Context, mgr Manager) error {
+	for i, bWf := range buildInWorflows {
+		old, err := mgr.GetWorkflow(ctx, bWf.Id)
+		if err != nil && err != types.ErrNotFound {
+			return fmt.Errorf("query workflow %s failed: %s", bWf.Id, err)
+		}
+
+		if err = createOrUpdateBuildInWorkflow(ctx, mgr, buildInWorflows[i], old); err != nil {
+			return fmt.Errorf("create or update workflow %s failed: %s", bWf.Id, err)
+		}
+	}
+	return nil
+}
+
+func createOrUpdateBuildInWorkflow(ctx context.Context, mgr Manager, expect, old *types.WorkflowSpec) error {
+	if old == nil {
+		_, err := mgr.CreateWorkflow(ctx, expect)
+		return err
+	}
+
+	if expect.Cron == old.Cron &&
+		reflect.DeepEqual(expect.Rule, old.Rule) &&
+		reflect.DeepEqual(expect.Steps, old.Steps) {
+		return nil
+	}
+
+	old.Cron = expect.Cron
+	old.Rule = expect.Rule
+	old.Steps = expect.Steps
+	_, err := mgr.UpdateWorkflow(ctx, old)
+	return err
+}
+
+var (
+	buildInWorflows = []*types.WorkflowSpec{
+		{
+
+			Id:   "internal.rss",
+			Name: "RSS Collect",
+			Rule: types.Rule{
+				Labels: &types.LabelMatch{
+					Include: []types.Label{
+						{Key: types.LabelKeyPluginKind, Value: string(types.TypeSource)},
+						{Key: types.LabelKeyPluginName, Value: "rss"},
+					},
+				},
+			},
+			Cron: "*/15 * * * *",
+			Steps: []types.WorkflowStepSpec{
+				{
+					Name: "collect",
+					Plugin: &types.PlugScope{
+						PluginName: "rss",
+						Version:    "1.0",
+						PluginType: types.TypeSource,
+						Parameters: map[string]string{},
+					},
+				},
+			},
+			Enable: true,
+		},
+		{
+			Id:   "internal.docload",
+			Name: "Document Load",
+			Rule: types.Rule{
+				Operation: types.RuleOpEndWith,
+				Column:    "name",
+				Value:     "html,htm,pdf",
+			},
+			Steps: []types.WorkflowStepSpec{
+				{
+					Name: "docload",
+					Plugin: &types.PlugScope{
+						PluginName: "docloader",
+						Version:    "1.0",
+						PluginType: types.TypeProcess,
+						Parameters: map[string]string{},
+					},
+				},
+				{
+					Name: "summary",
+					Plugin: &types.PlugScope{
+						PluginName: "summary",
+						Version:    "1.0",
+						PluginType: types.TypeProcess,
+						Parameters: map[string]string{},
+					},
+				},
+				{
+					Name: "keywords",
+					Plugin: &types.PlugScope{
+						PluginName: "keywords",
+						Version:    "1.0",
+						PluginType: types.TypeProcess,
+						Parameters: map[string]string{},
+					},
+				},
+			},
+			Enable: true,
+		},
+	}
+)

--- a/pkg/workflow/buildin.go
+++ b/pkg/workflow/buildin.go
@@ -60,7 +60,7 @@ var (
 	buildInWorflows = []*types.WorkflowSpec{
 		{
 
-			Id:   "internal.rss",
+			Id:   "buildin.rss",
 			Name: "RSS Collect",
 			Rule: types.Rule{
 				Labels: &types.LabelMatch{
@@ -85,7 +85,7 @@ var (
 			Enable: true,
 		},
 		{
-			Id:   "internal.docload",
+			Id:   "buildin.docload",
 			Name: "Document Load",
 			Rule: types.Rule{
 				Operation: types.RuleOpEndWith,

--- a/pkg/workflow/jobrun/controller_test.go
+++ b/pkg/workflow/jobrun/controller_test.go
@@ -48,7 +48,7 @@ var _ = Describe("TestJobPauseAndResume", func() {
 			Expect(err).Should(BeNil())
 		})
 		It("start should be succeed", func() {
-			Expect(ctrl.TriggerJob(ctx, job.Id)).Should(BeNil())
+			Expect(ctrl.TriggerJob(job.Id, time.Hour)).Should(BeNil())
 		})
 		It("wait first step status should be succeed", func() {
 			Eventually(func() string {
@@ -127,7 +127,7 @@ var _ = Describe("TestJobCancel", func() {
 			Expect(err).Should(BeNil())
 		})
 		It("start should be succeed", func() {
-			Expect(ctrl.TriggerJob(ctx, job.Id)).Should(BeNil())
+			Expect(ctrl.TriggerJob(job.Id, time.Hour)).Should(BeNil())
 		})
 		It("wait first step status should be succeed", func() {
 			Eventually(func() string {

--- a/pkg/workflow/jobrun/runner.go
+++ b/pkg/workflow/jobrun/runner.go
@@ -96,6 +96,7 @@ func (r *runner) Start(ctx context.Context) (err error) {
 	r.executor, err = newExecutor(defaultExecName, r.job)
 	if err != nil {
 		r.job.Status = FailedStatus
+		r.job.Message = err.Error()
 		r.logger.Errorw("build executor failed", "err", err)
 		return err
 	}
@@ -108,12 +109,14 @@ func (r *runner) Start(ctx context.Context) (err error) {
 
 	if err = r.executor.Setup(ctx); err != nil {
 		r.job.Status = ErrorStatus
+		r.job.Message = err.Error()
 		r.logger.Errorw("setup executor failed", "err", err)
 		return err
 	}
 
 	if err = r.pushEvent2FlowFSM(fsm.Event{Type: TriggerEvent, Status: r.job.Status, Obj: r.job}); err != nil {
 		r.job.Status = ErrorStatus
+		r.job.Message = err.Error()
 		r.logger.Errorw("trigger job failed", "err", err)
 		return err
 	}

--- a/pkg/workflow/suite_test.go
+++ b/pkg/workflow/suite_test.go
@@ -82,7 +82,7 @@ var _ = BeforeSuite(func() {
 	mgr, err = NewManager(entryMgr, docMgr, notify.NewNotify(memMeta), memMeta, config.Workflow{Enable: true, JobWorkdir: tempDir}, config.FUSE{})
 	Expect(err).Should(BeNil())
 
-	go mgr.StartCron(stopCh)
+	go mgr.Start(stopCh)
 })
 
 var _ = AfterSuite(func() {


### PR DESCRIPTION
- Init workflow build-rules: where the Workflow first queries for existence during initialization and creates it if it doesn't exist.
- Workflows now support automatic triggering based on rules for newly added entries.
- Event triggering needs to be consolidated at the Manager layer.
- Optimized the publishing of Entry events by asynchronously executing the sending action using entry ID only.
- ScheduledTask now supports direct registration to the event bus based on event types.
